### PR TITLE
Fix a Linking Issue on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ target_include_directories(
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
 )
 
-target_compile_definitions(LeapC++ PUBLIC LEAP_CPP_STATIC)
 if(WIN32)
   target_compile_options(LeapC++ PUBLIC "/wd4996")
 endif()

--- a/src/LeapC++.h
+++ b/src/LeapC++.h
@@ -19,13 +19,7 @@
 // Define Leap export macros
 #ifndef LEAP_EXPORT
   #if defined(_MSC_VER) // Visual C++
-    #if defined(LEAP_CPP_STATIC)
-      #define LEAP_EXPORT
-    #elif LEAP_CPP_IMPLEMENTATION
-      #define LEAP_EXPORT __declspec(dllexport)
-    #else
-      #define LEAP_EXPORT __declspec(dllimport)
-    #endif
+    #define LEAP_EXPORT
     #define LEAP_EXPORT_CLASS
   #elif !defined(SWIG)
     #define LEAP_EXPORT __attribute__((visibility("default")))

--- a/src/LeapC++.h
+++ b/src/LeapC++.h
@@ -19,7 +19,15 @@
 // Define Leap export macros
 #ifndef LEAP_EXPORT
   #if defined(_MSC_VER) // Visual C++
-    #define LEAP_EXPORT
+    #if defined(LEAP_CPP_DYNAMIC)
+      #if LEAP_CPP_IMPLEMENTATION
+        #define LEAP_EXPORT __declspec(dllexport)
+      #else
+        #define LEAP_EXPORT __declspec(dllimport)
+      #endif
+    #else
+      #define LEAP_EXPORT
+    #endif
     #define LEAP_EXPORT_CLASS
   #elif !defined(SWIG)
     #define LEAP_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
LeapC++ is built as a static library. When it is linked to another dll or static library on Windows, linker gives the following errors.

error LNK2019: unresolved external symbol "__declspec(dllimport) public: __cdecl Leap::Controller::Controller(char const *)" (__imp_??0Controller@Leap@@QEAA@PEBD@Z) referenced in function "public: __cdecl CNorthStarHandDriver::CNorthStarHandDriver(void)" (??0CNorthStarHandDriver@@QEAA@XZ)

This is jmarsden@leapmotion.com's fix.
